### PR TITLE
update drag speed computing logic, using distance between two instant

### DIFF
--- a/lib/drag_like.dart
+++ b/lib/drag_like.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-class DragLike extends StatefulWidget {
 
+class DragLike extends StatefulWidget {
   final Widget child;
   final Widget secondChild;
   final double screenWidth;
@@ -9,41 +9,47 @@ class DragLike extends StatefulWidget {
   final VoidCallback onScaleComplete;
   final ValueChanged<Map> onChangeDragDistance;
   final VoidCallback onPointerUp;
-  DragLike({
-    Key key,
-    @required this.child,
-    @required this.secondChild,
-    @required this.screenWidth,
-    @required this.outValue,
-    this.onOutComplete,
-    this.onScaleComplete,
-    this.onChangeDragDistance, 
-    this.onPointerUp
-    }) : assert(child != null) , 
-         assert(secondChild != null),
-         assert(screenWidth != null),
-         assert(outValue != null && outValue<=1 && outValue > 0),
-         super(key: key);
+  DragLike(
+      {Key key,
+      @required this.child,
+      @required this.secondChild,
+      @required this.screenWidth,
+      @required this.outValue,
+      this.onOutComplete,
+      this.onScaleComplete,
+      this.onChangeDragDistance,
+      this.onPointerUp})
+      : assert(child != null),
+        assert(secondChild != null),
+        assert(screenWidth != null),
+        assert(outValue != null && outValue <= 1 && outValue > 0),
+        super(key: key);
 
   @override
   _DragLikeState createState() => _DragLikeState();
 }
 
-class _DragLikeState extends State<DragLike> with TickerProviderStateMixin{
-
+class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
   // 滑动不到指定位置返回时的动画
   Animation animation;
   // 第二个页面动画到前面
   Animation scaleAnimation;
   // 按下时的X坐标，以此判断是左滑还是右滑
   double prevDx = 0;
+  // 拖拽时，上一瞬间x轴的位置
+  double lastPositionX = 0;
   // 屏幕宽度
   double get screenWidth => widget.screenWidth;
-  
   // 旋转角度
-  double angle=0;
+  double angle = 0;
   // 旋转时，x轴的偏移量
   double offsetX = 0;
+  // 拖拽时，两个瞬间之间，x轴的差值
+  double distanceBetweenTwo = 0;
+  // 拖拽发生的时间
+  DateTime dragTime;
+  // 拖拽速率，超过该速率时松手会划出卡片
+  double dragSpeedRatio = 85;
   // 第二层的缩放值，0-0.1，因为已设置初始值为0.9
   double secondScale = 0;
   // 拖拽距离比0.0-1
@@ -58,80 +64,110 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin{
   }
 
   // 更新偏移和缩放量
-  void updatePosition(positionX){
+  void updatePosition(positionX) {
     double offset = positionX - prevDx;
+    //上次两个瞬间的X轴距离
+    double lastDistance = (positionX - lastPositionX);
+    lastDistance = lastDistance.abs();
+    // 如果减速，重新开始计算时间
+    dragTime = DateTime.now();
+    // if (distanceBetweenTwo.abs() < lastDistance) {
+    // }
+    distanceBetweenTwo = positionX - lastPositionX;
+    print("distanceBetweenTwo = " + distanceBetweenTwo.toString());
+    lastPositionX = positionX;
+
     double offsetAbs = offset.abs();
-    double angleTemp = double.parse((offset/screenWidth/dragGvalue).toStringAsFixed(3));
+    double angleTemp =
+        double.parse((offset / screenWidth / dragGvalue).toStringAsFixed(3));
     if (angle != angleTemp) {
       angle = angleTemp;
-      secondScale = (offsetAbs/screenWidth/dragGvalue) / secondScaleSd;
-      if(secondScale >= 0.1) secondScale = 0.1;
-      dragDistance = offsetAbs/screenWidth;
-      if(offset<0) {
+      secondScale = (offsetAbs / screenWidth / dragGvalue) / secondScaleSd;
+      if (secondScale >= 0.1) secondScale = 0.1;
+      dragDistance = offsetAbs / screenWidth;
+      if (distanceBetweenTwo < 0) {
         offsetX = -80;
       } else {
         offsetX = 80;
       }
-      if (widget.onChangeDragDistance != null) {
-        double distance = offset/screenWidth;
-        double distanceProgress = distance / widget.outValue;
-        widget.onChangeDragDistance({'distance':distance,'distanceProgress':distanceProgress.abs()});
-      }
+
+      // if (widget.onChangeDragDistance != null) {
+      //   double distance = offset / screenWidth;
+      //   double distanceProgress = distance / widget.outValue;
+      //   widget.onChangeDragDistance({
+      //     'distance': distance,
+      //     'distanceProgress': distanceProgress.abs(),
+      //   });
+      // }
       setState(() {});
     }
   }
 
   // 上层以及第二层返回动画执行
-  runBackAnimate(){
+  runBackAnimate() {
     AnimationController controller;
-    controller =  AnimationController(duration: const Duration(milliseconds: 250), vsync: this);
-    this.animation = Tween<double>(begin: angle, end: 0).animate(controller)..addListener((){
-      angle = this.animation.value;
-      secondScale = angle.abs() / secondScaleSd;
-      if(secondScale <=0) secondScale = 0;
-      prevDx = 0;
-      dragDistance = 0;
-      if (controller.isCompleted) {
-        controller = null;
-      }
-      setState(() {});
-    });
-    controller.forward(from: 0);
-  }
-
-  void runOutAnimate(){
-    AnimationController controller;
-    controller =  AnimationController(duration: const Duration(milliseconds: 350), vsync: this);
-    this.animation = Tween<double>(begin: angle, end: angle > 0 ? 0.5 : -0.5).animate(controller)..addListener((){
-      angle = this.animation.value;
-      prevDx = 0;
-      dragDistance = 0;
-      if (controller.isCompleted) {
-        controller = null;
-      }
-      setState(() {});
-    });
-    controller.forward(from: 0);
-  }
-
-  void runInScaleAnimate() async{
-    AnimationController controller;
-    controller =  AnimationController(duration: const Duration(milliseconds: 350), vsync: this);
-    this.scaleAnimation = Tween<double>(begin:secondScale,end:0.1).animate(controller)..addListener(() async{
-      secondScale = this.scaleAnimation.value;
-      if(controller.isCompleted) {
-        if (widget.onScaleComplete!=null) {
-          widget.onScaleComplete();
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 250), vsync: this);
+    this.animation = Tween<double>(begin: angle, end: 0).animate(controller)
+      ..addListener(() {
+        angle = this.animation.value;
+        secondScale = angle.abs() / secondScaleSd;
+        if (secondScale <= 0) secondScale = 0;
+        prevDx = 0;
+        lastPositionX = 0;
+        dragDistance = 0;
+        if (controller.isCompleted) {
           controller = null;
         }
-        // 缩放完成以后，将上一层的widget还原到起始位置，不要动画，业务方需要将上层widget的数据替换
-        angle = 0;
-      }
-      setState(() {});
-    });
+        setState(() {});
+      });
     controller.forward(from: 0);
   }
-  
+
+  void runOutAnimate(int type) {
+    AnimationController controller;
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 350), vsync: this);
+    // direction: 判断卡片飞出方向的依据
+    double direction = distanceBetweenTwo;
+    if (type == 1) direction = angle;
+    this.animation =
+        Tween<double>(begin: angle, end: direction > 0 ? 0.5 : -0.5)
+            .animate(controller)
+              ..addListener(() {
+                angle = this.animation.value;
+                prevDx = 0;
+                lastPositionX = 0;
+                dragDistance = 0;
+                if (controller.isCompleted) {
+                  controller = null;
+                }
+                setState(() {});
+              });
+    controller.forward(from: 0);
+  }
+
+  void runInScaleAnimate() async {
+    AnimationController controller;
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 350), vsync: this);
+    this.scaleAnimation =
+        Tween<double>(begin: secondScale, end: 0.1).animate(controller)
+          ..addListener(() async {
+            secondScale = this.scaleAnimation.value;
+            if (controller.isCompleted) {
+              if (widget.onScaleComplete != null) {
+                widget.onScaleComplete();
+                controller = null;
+              }
+              // 缩放完成以后，将上一层的widget还原到起始位置，不要动画，业务方需要将上层widget的数据替换
+              angle = 0;
+            }
+            setState(() {});
+          });
+    controller.forward(from: 0);
+  }
+
   @override
   void dispose() {
     super.dispose();
@@ -140,43 +176,56 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin{
   @override
   Widget build(BuildContext context) {
     return Container(
-       child: Stack(
-         children: [
-           Transform.scale(
-            scale: 0.9 + secondScale,
-            child: widget.secondChild,
-           ),
-           Listener(
-             onPointerDown:(value){
-              prevDx = value.position.dx;
-             },
-             onPointerMove: (value){
-              updatePosition(value.position.dx);
-             },
-             onPointerUp: (value) async{
-               if(dragDistance > widget.outValue) {
-                 if (widget.onOutComplete != null) {
-                   widget.onOutComplete(offsetX > 0 ? 'right' : 'left');
-                 }
-                 runOutAnimate();
-                 runInScaleAnimate();
-               } else {
-                 runBackAnimate();
-               }
-               // 手指抬起时，回调给上层
-               if(widget.onPointerUp != null) {
-                 widget.onPointerUp();
-               }
-             },
-             child: Transform.rotate(
-              angle: angle,
-              origin: Offset(angle+offsetX,1500),
-              alignment: Alignment.lerp(Alignment.center, Alignment.bottomCenter, 1),
-              child: widget.child,
-            ),
-           )
-         ],
-       )
-    );
+        child: Stack(
+      children: [
+        Transform.scale(
+          scale: 0.9 + secondScale,
+          child: widget.secondChild,
+        ),
+        Listener(
+          onPointerDown: (value) {
+            prevDx = value.position.dx;
+            print("--------------------------------");
+          },
+          onPointerMove: (value) {
+            updatePosition(value.position.dx);
+          },
+          onPointerUp: (value) async {
+            // 计算“手指抬起”瞬间和上一个“减速/速度波谷”的瞬间的时间差
+            int timeOffset = DateTime.now().difference(dragTime).inMicroseconds;
+            //滑动速率 = 两个瞬间的距离 / 两个瞬间的时间差
+            print("distanceBetweenTwo = " + distanceBetweenTwo.toString());
+            double dragSpeed = (distanceBetweenTwo / timeOffset * 1e5).abs();
+            print("dragSpeed = " + dragSpeed.toString());
+            if (dragDistance > widget.outValue || dragSpeed >= dragSpeedRatio) {
+              if (widget.onOutComplete != null) {
+                widget.onOutComplete(offsetX > 0 ? 'right' : 'left');
+              }
+              if (dragDistance > widget.outValue) {
+                runOutAnimate(1); //以angle是否达到出界angle判断
+                print("type: outValue");
+              } else {
+                runOutAnimate(-1); //以两个瞬间滑动的方向来判断
+                print("type: speed direction");
+              }
+              runInScaleAnimate();
+            } else {
+              runBackAnimate();
+            }
+            // 手指抬起时，回调给上层
+            if (widget.onPointerUp != null) {
+              widget.onPointerUp();
+            }
+          },
+          child: Transform.rotate(
+            angle: angle,
+            origin: Offset(angle + offsetX, 1500),
+            alignment:
+                Alignment.lerp(Alignment.center, Alignment.bottomCenter, 1),
+            child: widget.child,
+          ),
+        )
+      ],
+    ));
   }
 }


### PR DESCRIPTION
**修改：滑动判定改为：用滑动的前后2个瞬间的距离和方向判断是否划出卡片**
**目标效果：**
1. 滑动距离不够的情况下，手指须为快速滑动并且快速抬起，卡片才需要划出屏幕。
2. A-B-C，滑动距离不够的情况下，A点到B点为慢速，B点到C点为快速，卡片也应该划出屏幕。

**实现第1个效果**
因为原先的dragDistance = offsetAbs / screenWidth;表现为当前卡片的位置，用来判定滑动距离会有问题，
现改用两个瞬间的位置差distanceBetweenTwo来表示
**实现第2个效果**
用两个瞬间的位置差distanceBetweenTwo来表示之后，在人类的操作速度内，两个瞬间内，不可能在做到A-B-C的同时，速度达到阈值。
即不会出现A-B-C，A = 0， B=50，C=20，记录distanceBetweenTwo为【C-A=20】的情况，而判定为**向右划出（错误）**
当且仅当A-B-C，A = 0， B=50，C=20，记录distanceBetweenTwo为【C-B=-30】时，判定为**向左划出（正确）**
同理A = 0， B=50，C=90，记录distanceBetweenTwo为【C-B=40】时，判定为**向右划出（正确）**

修改内容：
- 保持 dragDistance 功能不变，用来检测outValue，滑动到一定距离时，判定为划出
- 新增变量 distanceBetweenTwo：记录滑动发生的前后2个瞬间【distanceBetweenTwo = positionX - lastPositionX;】
- 新增变量 lastPositionX：记录滑动的上1个瞬间的位置
- 更新 dragSpeed = distanceBetweenTwo / timeOffset
- 函数 runOutAnimate() 改为 runOutAnimate(int type) —— 用type记录滑卡发生时的判定条件①outValue②drag speed，避免出现因滑动速度快，A-B-C，实际应该是B-C方向划出，而被认为是A-C（因为原本用angle来判断）