### PR TITLE
fix card up and down problem, fix when finger flit screen, touch twice for an instant can be treat as swipe out

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,7 +11,6 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-
   List data = [
     'https://gimg2.baidu.com/image_search/src=http%3A%2F%2Fn.sinaimg.cn%2Fsinacn20%2F170%2Fw1024h1546%2F20180318%2Fa00d-fyshfur3814572.jpg&refer=http%3A%2F%2Fn.sinaimg.cn&app=2002&size=f9999,10000&q=a80&n=0&g=0n&fmt=jpeg?sec=1613903060&t=651082a2ee0be03315c114381adaea8dhttps://gimg2.baidu.com/image_search/src=http%3A%2F%2Fn.sinaimg.cn%2Fsinacn20%2F170%2Fw1024h1546%2F20180318%2Fa00d-fyshfur3814572.jpg&refer=http%3A%2F%2Fn.sinaimg.cn&app=2002&size=f9999,10000&q=a80&n=0&g=0n&fmt=jpeg?sec=1613903060&t=651082a2ee0be03315c114381adaea8d',
     'https://gimg2.baidu.com/image_search/src=http%3A%2F%2Fn1.itc.cn%2Fimg8%2Fwb%2Frecom%2F2016%2F05%2F19%2F146364216575228138.JPEG&refer=http%3A%2F%2Fn1.itc.cn&app=2002&size=f9999,10000&q=a80&n=0&g=0n&fmt=jpeg?sec=1614001788&t=3727c8bd4ef9b45d3749fa42a6f28081',
@@ -25,7 +24,7 @@ class _MyAppState extends State<MyApp> {
 
   List imagelist = [];
 
-  void loaddata() async{
+  void loaddata() async {
     await Future.delayed(Duration(milliseconds: 2000));
     imagelist.addAll(data);
     setState(() {});
@@ -36,6 +35,7 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     loaddata();
   }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -45,50 +45,49 @@ class _MyAppState extends State<MyApp> {
         ),
         body: Center(
           child: Container(
-            width: double.infinity,
-            height: double.infinity,
-            margin: EdgeInsets.only(left:10,right:10,top:10,bottom: 10),
-            child: Stack(
-              children: [
-                DragLike(
-                  child: imagelist.length <=0 ? Text('加载中...') : ClipRRect(
-                    borderRadius: BorderRadius.circular(10),
-                    child: TestDrag(src:imagelist[0])
-                  ), 
-                  secondChild: imagelist.length <= 1 ? Container(): ClipRRect(
-                    borderRadius: BorderRadius.circular(10),
-                    child:TestDrag(src:imagelist[1])
-                  ), 
-                  screenWidth: 375, 
-                  outValue: 0.6,
-                  onChangeDragDistance: (distance){
-                    /// {distance: 0.17511112467447917, distanceProgress: 0.2918518744574653}
-                    print(distance.toString());
-                  },
-                  onOutComplete: (type){
-                    /// left or right
-                    print(type);
-                  },
-                  onScaleComplete: (){
-                    imagelist.remove(imagelist[0]);
-                    if(imagelist.length == 0) {
-                     loaddata();
-                    }
-                    setState(() {});
-                  },
-                  onPointerUp: (){
-                    
-                  },
-                ),
-              ],
-            )
-          ),
+              width: double.infinity,
+              height: double.infinity,
+              margin: EdgeInsets.only(left: 10, right: 10, top: 10, bottom: 10),
+              child: Stack(
+                children: [
+                  DragLike(
+                    child: imagelist.length <= 0
+                        ? Text('加载中...')
+                        : ClipRRect(
+                            borderRadius: BorderRadius.circular(10),
+                            child: TestDrag(src: imagelist[0])),
+                    secondChild: imagelist.length <= 1
+                        ? Container()
+                        : ClipRRect(
+                            borderRadius: BorderRadius.circular(10),
+                            child: TestDrag(src: imagelist[1])),
+                    screenWidth: 375,
+                    outValue: 0.4,
+                    dragSpeedRatio: 80,
+                    onChangeDragDistance: (distance) {
+                      /// {distance: 0.17511112467447917, distanceProgress: 0.2918518744574653}
+                      print(distance.toString());
+                    },
+                    onOutComplete: (type) {
+                      /// left or right
+                      print(type);
+                    },
+                    onScaleComplete: () {
+                      imagelist.remove(imagelist[0]);
+                      if (imagelist.length == 0) {
+                        loaddata();
+                      }
+                      setState(() {});
+                    },
+                    onPointerUp: () {},
+                  ),
+                ],
+              )),
         ),
       ),
     );
   }
 }
-
 
 class TestDrag extends StatelessWidget {
   final String src;
@@ -100,7 +99,10 @@ class TestDrag extends StatelessWidget {
       width: double.infinity,
       height: double.infinity,
       color: Colors.grey,
-      child: Image.network(src,fit: BoxFit.cover,),
+      child: Image.network(
+        src,
+        fit: BoxFit.cover,
+      ),
     );
   }
 }

--- a/lib/drag_like.dart
+++ b/lib/drag_like.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-class DragLike extends StatefulWidget {
 
+class DragLike extends StatefulWidget {
   final Widget child;
   final Widget secondChild;
   final double screenWidth;
@@ -9,41 +9,47 @@ class DragLike extends StatefulWidget {
   final VoidCallback onScaleComplete;
   final ValueChanged<Map> onChangeDragDistance;
   final VoidCallback onPointerUp;
-  DragLike({
-    Key key,
-    @required this.child,
-    @required this.secondChild,
-    @required this.screenWidth,
-    @required this.outValue,
-    this.onOutComplete,
-    this.onScaleComplete,
-    this.onChangeDragDistance, 
-    this.onPointerUp
-    }) : assert(child != null) , 
-         assert(secondChild != null),
-         assert(screenWidth != null),
-         assert(outValue != null && outValue<=1 && outValue > 0),
-         super(key: key);
+  DragLike(
+      {Key key,
+      @required this.child,
+      @required this.secondChild,
+      @required this.screenWidth,
+      @required this.outValue,
+      this.onOutComplete,
+      this.onScaleComplete,
+      this.onChangeDragDistance,
+      this.onPointerUp})
+      : assert(child != null),
+        assert(secondChild != null),
+        assert(screenWidth != null),
+        assert(outValue != null && outValue <= 1 && outValue > 0),
+        super(key: key);
 
   @override
   _DragLikeState createState() => _DragLikeState();
 }
 
-class _DragLikeState extends State<DragLike> with TickerProviderStateMixin{
-
+class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
   // 滑动不到指定位置返回时的动画
   Animation animation;
   // 第二个页面动画到前面
   Animation scaleAnimation;
   // 按下时的X坐标，以此判断是左滑还是右滑
   double prevDx = 0;
+  // 拖拽时，上一瞬间x轴的位置
+  double lastPositionX = 0;
   // 屏幕宽度
   double get screenWidth => widget.screenWidth;
-  
   // 旋转角度
-  double angle=0;
+  double angle = 0;
   // 旋转时，x轴的偏移量
   double offsetX = 0;
+  // 拖拽时，两个瞬间之间，x轴的差值
+  double distanceBetweenTwo = 0;
+  // 拖拽发生的时间
+  DateTime dragTime;
+  // 拖拽速率，超过该速率时松手会划出卡片
+  double dragSpeedRatio = 85;
   // 第二层的缩放值，0-0.1，因为已设置初始值为0.9
   double secondScale = 0;
   // 拖拽距离比0.0-1
@@ -58,80 +64,110 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin{
   }
 
   // 更新偏移和缩放量
-  void updatePosition(positionX){
+  void updatePosition(positionX) {
     double offset = positionX - prevDx;
+    //上次两个瞬间的X轴距离
+    double lastDistance = (positionX - lastPositionX);
+    lastDistance = lastDistance.abs();
+    // 如果减速，重新开始计算时间
+    dragTime = DateTime.now();
+    // if (distanceBetweenTwo.abs() < lastDistance) {
+    // }
+    distanceBetweenTwo = positionX - lastPositionX;
+    print("distanceBetweenTwo = " + distanceBetweenTwo.toString());
+    lastPositionX = positionX;
+
     double offsetAbs = offset.abs();
-    double angleTemp = double.parse((offset/screenWidth/dragGvalue).toStringAsFixed(3));
+    double angleTemp =
+        double.parse((offset / screenWidth / dragGvalue).toStringAsFixed(3));
     if (angle != angleTemp) {
       angle = angleTemp;
-      secondScale = (offsetAbs/screenWidth/dragGvalue) / secondScaleSd;
-      if(secondScale >= 0.1) secondScale = 0.1;
-      dragDistance = offsetAbs/screenWidth;
-      if(offset<0) {
+      secondScale = (offsetAbs / screenWidth / dragGvalue) / secondScaleSd;
+      if (secondScale >= 0.1) secondScale = 0.1;
+      dragDistance = offsetAbs / screenWidth;
+      if (distanceBetweenTwo < 0) {
         offsetX = -80;
       } else {
         offsetX = 80;
       }
-      if (widget.onChangeDragDistance != null) {
-        double distance = offset/screenWidth;
-        double distanceProgress = distance / widget.outValue;
-        widget.onChangeDragDistance({'distance':distance,'distanceProgress':distanceProgress.abs()});
-      }
+
+      // if (widget.onChangeDragDistance != null) {
+      //   double distance = offset / screenWidth;
+      //   double distanceProgress = distance / widget.outValue;
+      //   widget.onChangeDragDistance({
+      //     'distance': distance,
+      //     'distanceProgress': distanceProgress.abs(),
+      //   });
+      // }
       setState(() {});
     }
   }
 
   // 上层以及第二层返回动画执行
-  runBackAnimate(){
+  runBackAnimate() {
     AnimationController controller;
-    controller =  AnimationController(duration: const Duration(milliseconds: 250), vsync: this);
-    this.animation = Tween<double>(begin: angle, end: 0).animate(controller)..addListener((){
-      angle = this.animation.value;
-      secondScale = angle.abs() / secondScaleSd;
-      if(secondScale <=0) secondScale = 0;
-      prevDx = 0;
-      dragDistance = 0;
-      if (controller.isCompleted) {
-        controller = null;
-      }
-      setState(() {});
-    });
-    controller.forward(from: 0);
-  }
-
-  void runOutAnimate(){
-    AnimationController controller;
-    controller =  AnimationController(duration: const Duration(milliseconds: 350), vsync: this);
-    this.animation = Tween<double>(begin: angle, end: angle > 0 ? 0.5 : -0.5).animate(controller)..addListener((){
-      angle = this.animation.value;
-      prevDx = 0;
-      dragDistance = 0;
-      if (controller.isCompleted) {
-        controller = null;
-      }
-      setState(() {});
-    });
-    controller.forward(from: 0);
-  }
-
-  void runInScaleAnimate() async{
-    AnimationController controller;
-    controller =  AnimationController(duration: const Duration(milliseconds: 350), vsync: this);
-    this.scaleAnimation = Tween<double>(begin:secondScale,end:0.1).animate(controller)..addListener(() async{
-      secondScale = this.scaleAnimation.value;
-      if(controller.isCompleted) {
-        if (widget.onScaleComplete!=null) {
-          widget.onScaleComplete();
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 250), vsync: this);
+    this.animation = Tween<double>(begin: angle, end: 0).animate(controller)
+      ..addListener(() {
+        angle = this.animation.value;
+        secondScale = angle.abs() / secondScaleSd;
+        if (secondScale <= 0) secondScale = 0;
+        prevDx = 0;
+        lastPositionX = 0;
+        dragDistance = 0;
+        if (controller.isCompleted) {
           controller = null;
         }
-        // 缩放完成以后，将上一层的widget还原到起始位置，不要动画，业务方需要将上层widget的数据替换
-        angle = 0;
-      }
-      setState(() {});
-    });
+        setState(() {});
+      });
     controller.forward(from: 0);
   }
-  
+
+  void runOutAnimate(int type) {
+    AnimationController controller;
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 350), vsync: this);
+    // direction: 判断卡片飞出方向的依据
+    double direction = distanceBetweenTwo;
+    if (type == 1) direction = angle;
+    this.animation =
+        Tween<double>(begin: angle, end: direction > 0 ? 0.5 : -0.5)
+            .animate(controller)
+              ..addListener(() {
+                angle = this.animation.value;
+                prevDx = 0;
+                lastPositionX = 0;
+                dragDistance = 0;
+                if (controller.isCompleted) {
+                  controller = null;
+                }
+                setState(() {});
+              });
+    controller.forward(from: 0);
+  }
+
+  void runInScaleAnimate() async {
+    AnimationController controller;
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 350), vsync: this);
+    this.scaleAnimation =
+        Tween<double>(begin: secondScale, end: 0.1).animate(controller)
+          ..addListener(() async {
+            secondScale = this.scaleAnimation.value;
+            if (controller.isCompleted) {
+              if (widget.onScaleComplete != null) {
+                widget.onScaleComplete();
+                controller = null;
+              }
+              // 缩放完成以后，将上一层的widget还原到起始位置，不要动画，业务方需要将上层widget的数据替换
+              angle = 0;
+            }
+            setState(() {});
+          });
+    controller.forward(from: 0);
+  }
+
   @override
   void dispose() {
     super.dispose();
@@ -140,43 +176,56 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin{
   @override
   Widget build(BuildContext context) {
     return Container(
-       child: Stack(
-         children: [
-           Transform.scale(
-            scale: 0.9 + secondScale,
-            child: widget.secondChild,
-           ),
-           Listener(
-             onPointerDown:(value){
-              prevDx = value.position.dx;
-             },
-             onPointerMove: (value){
-              updatePosition(value.position.dx);
-             },
-             onPointerUp: (value) async{
-               if(dragDistance > widget.outValue) {
-                 if (widget.onOutComplete != null) {
-                   widget.onOutComplete(offsetX > 0 ? 'right' : 'left');
-                 }
-                 runOutAnimate();
-                 runInScaleAnimate();
-               } else {
-                 runBackAnimate();
-               }
-               // 手指抬起时，回调给上层
-               if(widget.onPointerUp != null) {
-                 widget.onPointerUp();
-               }
-             },
-             child: Transform.rotate(
-              angle: angle,
-              origin: Offset(angle+offsetX,1500),
-              alignment: Alignment.lerp(Alignment.center, Alignment.bottomCenter, 1),
-              child: widget.child,
-            ),
-           )
-         ],
-       )
-    );
+        child: Stack(
+      children: [
+        Transform.scale(
+          scale: 0.9 + secondScale,
+          child: widget.secondChild,
+        ),
+        Listener(
+          onPointerDown: (value) {
+            prevDx = value.position.dx;
+            print("--------------------------------");
+          },
+          onPointerMove: (value) {
+            updatePosition(value.position.dx);
+          },
+          onPointerUp: (value) async {
+            // 计算“手指抬起”瞬间和上一个“减速/速度波谷”的瞬间的时间差
+            int timeOffset = DateTime.now().difference(dragTime).inMicroseconds;
+            //滑动速率 = 两个瞬间的距离 / 两个瞬间的时间差
+            print("distanceBetweenTwo = " + distanceBetweenTwo.toString());
+            double dragSpeed = (distanceBetweenTwo / timeOffset * 1e5).abs();
+            print("dragSpeed = " + dragSpeed.toString());
+            if (dragDistance > widget.outValue || dragSpeed >= dragSpeedRatio) {
+              if (widget.onOutComplete != null) {
+                widget.onOutComplete(offsetX > 0 ? 'right' : 'left');
+              }
+              if (dragDistance > widget.outValue) {
+                runOutAnimate(1); //以angle是否达到出界angle判断
+                print("type: outValue");
+              } else {
+                runOutAnimate(-1); //以两个瞬间滑动的方向来判断
+                print("type: speed direction");
+              }
+              runInScaleAnimate();
+            } else {
+              runBackAnimate();
+            }
+            // 手指抬起时，回调给上层
+            if (widget.onPointerUp != null) {
+              widget.onPointerUp();
+            }
+          },
+          child: Transform.rotate(
+            angle: angle,
+            origin: Offset(angle + offsetX, 1500),
+            alignment:
+                Alignment.lerp(Alignment.center, Alignment.bottomCenter, 1),
+            child: widget.child,
+          ),
+        )
+      ],
+    ));
   }
 }

--- a/lib/drag_like.dart
+++ b/lib/drag_like.dart
@@ -5,6 +5,7 @@ class DragLike extends StatefulWidget {
   final Widget secondChild;
   final double screenWidth;
   final double outValue;
+  final double dragSpeedRatio;
   final ValueChanged<String> onOutComplete;
   final VoidCallback onScaleComplete;
   final ValueChanged<Map> onChangeDragDistance;
@@ -15,6 +16,7 @@ class DragLike extends StatefulWidget {
       @required this.secondChild,
       @required this.screenWidth,
       @required this.outValue,
+      @required this.dragSpeedRatio,
       this.onOutComplete,
       this.onScaleComplete,
       this.onChangeDragDistance,
@@ -23,6 +25,7 @@ class DragLike extends StatefulWidget {
         assert(secondChild != null),
         assert(screenWidth != null),
         assert(outValue != null && outValue <= 1 && outValue > 0),
+        assert(dragSpeedRatio != null && dragSpeedRatio > 0),
         super(key: key);
 
   @override
@@ -35,7 +38,7 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
   // 第二个页面动画到前面
   Animation scaleAnimation;
   // 按下时的X坐标，以此判断是左滑还是右滑
-  double prevDx = 0;
+  double onPressDx = 0;
   // 拖拽时，上一瞬间x轴的位置
   double lastPositionX = 0;
   // 屏幕宽度
@@ -48,8 +51,6 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
   double distanceBetweenTwo = 0;
   // 拖拽发生的时间
   DateTime dragTime;
-  // 拖拽速率，超过该速率时松手会划出卡片
-  double dragSpeedRatio = 85;
   // 第二层的缩放值，0-0.1，因为已设置初始值为0.9
   double secondScale = 0;
   // 拖拽距离比0.0-1
@@ -65,19 +66,19 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
 
   // 更新偏移和缩放量
   void updatePosition(positionX) {
-    double offset = positionX - prevDx;
-    //上次两个瞬间的X轴距离
-    double lastDistance = (positionX - lastPositionX);
-    lastDistance = lastDistance.abs();
-    // 如果减速，重新开始计算时间
+    print("positionX = " + positionX.toString());
+    print("lastPositionX = " + lastPositionX.toString());
+    double offset = positionX - onPressDx;
+    print("offset = " + offset.toString());
+
     dragTime = DateTime.now();
-    // if (distanceBetweenTwo.abs() < lastDistance) {
-    // }
+
     distanceBetweenTwo = positionX - lastPositionX;
     print("distanceBetweenTwo = " + distanceBetweenTwo.toString());
     lastPositionX = positionX;
 
     double offsetAbs = offset.abs();
+    print("offsetAbs = " + offsetAbs.toString());
     double angleTemp =
         double.parse((offset / screenWidth / dragGvalue).toStringAsFixed(3));
     if (angle != angleTemp) {
@@ -85,7 +86,9 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
       secondScale = (offsetAbs / screenWidth / dragGvalue) / secondScaleSd;
       if (secondScale >= 0.1) secondScale = 0.1;
       dragDistance = offsetAbs / screenWidth;
-      if (distanceBetweenTwo < 0) {
+      print("dragDistance = " + dragDistance.toString());
+
+      if (offset < 0) {
         offsetX = -80;
       } else {
         offsetX = 80;
@@ -113,8 +116,7 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
         angle = this.animation.value;
         secondScale = angle.abs() / secondScaleSd;
         if (secondScale <= 0) secondScale = 0;
-        prevDx = 0;
-        lastPositionX = 0;
+
         dragDistance = 0;
         if (controller.isCompleted) {
           controller = null;
@@ -136,8 +138,7 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
             .animate(controller)
               ..addListener(() {
                 angle = this.animation.value;
-                prevDx = 0;
-                lastPositionX = 0;
+
                 dragDistance = 0;
                 if (controller.isCompleted) {
                   controller = null;
@@ -184,28 +185,34 @@ class _DragLikeState extends State<DragLike> with TickerProviderStateMixin {
         ),
         Listener(
           onPointerDown: (value) {
-            prevDx = value.position.dx;
+            onPressDx = value.position.dx;
+            lastPositionX = onPressDx;
             print("--------------------------------");
           },
           onPointerMove: (value) {
             updatePosition(value.position.dx);
           },
           onPointerUp: (value) async {
-            // 计算“手指抬起”瞬间和上一个“减速/速度波谷”的瞬间的时间差
             int timeOffset = DateTime.now().difference(dragTime).inMicroseconds;
             //滑动速率 = 两个瞬间的距离 / 两个瞬间的时间差
-            print("distanceBetweenTwo = " + distanceBetweenTwo.toString());
+            print("timeOffset = " + timeOffset.toString());
+            if (timeOffset < 5000)
+              timeOffset = 7500;
+            else if (timeOffset < 8000) timeOffset = 10000;
             double dragSpeed = (distanceBetweenTwo / timeOffset * 1e5).abs();
+
+            print("distanceBetweenTwo = " + distanceBetweenTwo.toString());
             print("dragSpeed = " + dragSpeed.toString());
-            if (dragDistance > widget.outValue || dragSpeed >= dragSpeedRatio) {
-              if (widget.onOutComplete != null) {
-                widget.onOutComplete(offsetX > 0 ? 'right' : 'left');
-              }
+            if (dragDistance > widget.outValue || dragSpeed >= widget.dragSpeedRatio) {
               if (dragDistance > widget.outValue) {
-                runOutAnimate(1); //以angle是否达到出界angle判断
+                //以angle是否达到出界angle判断
+                runOutAnimate(1); 
+                print(offsetX > 0 ? 'right' : 'left');
                 print("type: outValue");
               } else {
-                runOutAnimate(-1); //以两个瞬间滑动的方向来判断
+                //以两个瞬间滑动的方向来判断
+                runOutAnimate(-1); 
+                print(distanceBetweenTwo > 0 ? 'right' : 'left');
                 print("type: speed direction");
               }
               runInScaleAnimate();


### PR DESCRIPTION
**问题修复：**
1、按住卡片将卡片向右移/左移时，手指不抬起，改变方向移动时，卡片有比较明显的下沉动作，下沉后，恢复移动方向时，有比较明显的上移动作。
2、按住卡片将卡片向右移/左移时，停顿一下后抬起手指，手指抬起的时候，可能会有向相反方向移动比较微小的距离（手抖或者不经意），此时卡片则会向相反方向移除屏幕。


**问题1：**
**解决方式：**
误将设定offsetX的判定条件改动，改回用 offset > 0 判断后恢复正常
**问题2：**
分析了一下出现这种情况的原因，可能是因为手指略过屏幕的时候判定了2次点击，因为runOut和runBack的动画都是在onPointerUp中进行async异步执行，会出现等到runOutAnimate()执行时，将原本prevDx和lastPositionXassign在第2次onPointerDown时赋值后的值用“0”覆盖，此时计算【positionX -  lastPositionXassign】就会导致值出错，出现了在极短时间内滑动很大距离的情况。

**解决的方式：**

- 不在runOut和runBack的function下面执行重新赋值为0的操作，只在onPointerDown时候初次assign当前X轴位置给prevDx和lastPositionX，并在updatePosition中不断更新lastPositionX
- 通过将timeOffset < 一定值的情况视为误触，并将timeOffset较小时分层级赋值为更大的值，以避免手指划过屏幕，误判2次点击为划出的情况

**修改内容：**
- prevDx其实作用是用来判定用户按下的位置，结合之后手指拖拽到的位置和最开始的位置，计算卡片的动画。——所以改其命名为onPressDx
- 将dragSpeedRatio作为必要传入参数，当数值越大，判定为划出卡片的速度要求就越高
- 修改outValue为0.4，原先默认的0.6，使用起来常常要手指滑到最边缘